### PR TITLE
Fixed namespaces for usage of doctrine-persistence:1.3.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,6 +39,7 @@
         "doctrine/doctrine-module": "^1.2",
         "doctrine/orm": "^2.5",
         "doctrine/mongodb-odm": "^1.1",
+        "doctrine/persistence": "^1.3",
         "ramsey/uuid": "^3.4",
         "ramsey/uuid-doctrine": "^1.2"
     },
@@ -48,6 +49,7 @@
         "zendframework/zend-paginator": "For usage of the Doctrine ORM/ODM based repositories",
         "doctrine/doctrine-module": "For usage of the Doctrine/Zend Cache bridge",
         "doctrine/doctrine-orm-module": "For usage of the Doctrine ORM based repository",
+        "doctrine/doctrine/persistence": "For usage of the Doctrine ORM based repository",
         "doctrine/doctrine-mongo-odm-module": "For usage of the Doctrine ODM based repository",
         "alcaeus/mongo-php-adapter": "For usage of the Doctrine ODM based repository (until doctrine-mongo-odm is ported to ext-mongodb)",
         "ramsey/uuid": "For usage of the Doctrine ODM \"uuid\" mapping type",

--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,7 @@
         "zendframework/zend-stdlib": "^3.0.1"
     },
     "require-dev": {
+        "ext-mongo": "*",
         "phpunit/phpunit": "^7.0",
         "squizlabs/php_codesniffer" : "^3.2",
         "phpmd/phpmd": "^2.2",
@@ -36,7 +37,7 @@
         "detailnet/dfw-commanding": "^1.1",
         "detailnet/dfw-filtering": "^1.0",
         "zendframework/zend-paginator": "^2.7",
-        "doctrine/doctrine-module": "^1.2",
+        "doctrine/doctrine-module": "^2.1",
         "doctrine/orm": "^2.5",
         "doctrine/mongodb-odm": "^1.1",
         "doctrine/persistence": "^1.3",
@@ -49,9 +50,9 @@
         "zendframework/zend-paginator": "For usage of the Doctrine ORM/ODM based repositories",
         "doctrine/doctrine-module": "For usage of the Doctrine/Zend Cache bridge",
         "doctrine/doctrine-orm-module": "For usage of the Doctrine ORM based repository",
-        "doctrine/doctrine/persistence": "For usage of the Doctrine ORM based repository",
         "doctrine/doctrine-mongo-odm-module": "For usage of the Doctrine ODM based repository",
-        "alcaeus/mongo-php-adapter": "For usage of the Doctrine ODM based repository (until doctrine-mongo-odm is ported to ext-mongodb)",
+        "doctrine/persistence": "For usage of the Doctrine ORM and/or ODM based repository",
+        "alcaeus/mongo-php-adapter": "For usage of the Doctrine ODM based repository (until doctrine/mongodb-odm is ported to ext-mongodb)",
         "ramsey/uuid": "For usage of the Doctrine ODM \"uuid\" mapping type",
         "ramsey/uuid-doctrine": "For usage of the Doctrine ORM \"uuid\" mapping type"
     },

--- a/src/Collection/CollectionInterface.php
+++ b/src/Collection/CollectionInterface.php
@@ -2,6 +2,8 @@
 
 namespace Detail\Persistence\Collection;
 
-interface CollectionInterface extends \IteratorAggregate
+use IteratorAggregate;
+
+interface CollectionInterface extends IteratorAggregate
 {
 }

--- a/src/Doctrine/ODM/Id/UuidGenerator.php
+++ b/src/Doctrine/ODM/Id/UuidGenerator.php
@@ -13,7 +13,7 @@ class UuidGenerator extends AbstractIdGenerator
     /**
      * Generates an identifier for a document.
      *
-     * @param \Doctrine\ODM\MongoDB\DocumentManager $dm
+     * @param DocumentManager $dm
      * @param object $document
      * @return UuidInterface
      */

--- a/src/Doctrine/ODM/Types/UuidType.php
+++ b/src/Doctrine/ODM/Types/UuidType.php
@@ -46,9 +46,7 @@ class UuidType extends Type
             return $value;
         }
 
-        $uuid = Uuid::fromString($value);
-
-        return $uuid;
+        return Uuid::fromString($value);
     }
 
     /**

--- a/src/Doctrine/ORM/Repository/BaseEntityRepository.php
+++ b/src/Doctrine/ORM/Repository/BaseEntityRepository.php
@@ -348,9 +348,7 @@ abstract class BaseEntityRepository extends Repository\BaseRepository implements
 
         /** @todo Check if collection class implements pagination (Zend\Paginator\Paginator) */
 
-        $collection = new $collectionClass($paginatorAdapter);
-
-        return $collection;
+        return new $collectionClass($paginatorAdapter);
     }
 
     /**
@@ -564,9 +562,8 @@ abstract class BaseEntityRepository extends Repository\BaseRepository implements
     protected function getEntityAlias()
     {
         $nameParts = explode('\\', $this->getEntityName());
-        $alias = lcfirst($nameParts[count($nameParts) - 1]);
 
-        return $alias;
+        return lcfirst($nameParts[count($nameParts) - 1]);
     }
 
     /**
@@ -630,9 +627,7 @@ abstract class BaseEntityRepository extends Repository\BaseRepository implements
     protected function getIdentifier($value)
     {
         // Sub classes can determine the identifier to use based on the provided entity/value.
-        $identifier = null;
-
-        return $identifier;
+        return null;
     }
 
     /**

--- a/src/Doctrine/ObjectManagerAwareTrait.php
+++ b/src/Doctrine/ObjectManagerAwareTrait.php
@@ -2,7 +2,7 @@
 
 namespace Detail\Persistence\Doctrine;
 
-use Doctrine\Common\Persistence\ObjectManager as ObjectManagerInterface;
+use Doctrine\Persistence\ObjectManager as ObjectManagerInterface;
 
 trait ObjectManagerAwareTrait
 {

--- a/src/Doctrine/ObjectManagerAwareTrait.php
+++ b/src/Doctrine/ObjectManagerAwareTrait.php
@@ -2,17 +2,17 @@
 
 namespace Detail\Persistence\Doctrine;
 
-use Doctrine\Persistence\ObjectManager as ObjectManagerInterface;
+use Doctrine\Persistence\ObjectManager;
 
 trait ObjectManagerAwareTrait
 {
     /**
-     * @var ObjectManagerInterface
+     * @var ObjectManager
      */
     protected $objectManager;
 
     /**
-     * @return ObjectManagerInterface
+     * @return ObjectManager
      */
     public function getObjectManager()
     {
@@ -20,9 +20,9 @@ trait ObjectManagerAwareTrait
     }
 
     /**
-     * @param ObjectManagerInterface $objectManager
+     * @param ObjectManager $objectManager
      */
-    public function setObjectManager(ObjectManagerInterface $objectManager)
+    public function setObjectManager(ObjectManager $objectManager)
     {
         $this->objectManager = $objectManager;
     }

--- a/src/Doctrine/ObjectManagersAwareTrait.php
+++ b/src/Doctrine/ObjectManagersAwareTrait.php
@@ -2,17 +2,17 @@
 
 namespace Detail\Persistence\Doctrine;
 
-use Doctrine\Persistence\ObjectManager as ObjectManagerInterface;
+use Doctrine\Persistence\ObjectManager;
 
 trait ObjectManagersAwareTrait
 {
     /**
-     * @var ObjectManagerInterface[]
+     * @var ObjectManager[]
      */
     protected $objectManagers = [];
 
     /**
-     * @return ObjectManagerInterface[]
+     * @return ObjectManager[]
      */
     public function getObjectManagers()
     {
@@ -20,7 +20,7 @@ trait ObjectManagersAwareTrait
     }
 
     /**
-     * @param ObjectManagerInterface[] $objectManagers
+     * @param ObjectManager[] $objectManagers
      */
     public function setObjectManagers(array $objectManagers)
     {

--- a/src/Doctrine/ObjectManagersAwareTrait.php
+++ b/src/Doctrine/ObjectManagersAwareTrait.php
@@ -2,7 +2,7 @@
 
 namespace Detail\Persistence\Doctrine;
 
-use Doctrine\Common\Persistence\ObjectManager as ObjectManagerInterface;
+use Doctrine\Persistence\ObjectManager as ObjectManagerInterface;
 
 trait ObjectManagersAwareTrait
 {

--- a/src/Factory/Doctrine/DocumentRepositoryFactory.php
+++ b/src/Factory/Doctrine/DocumentRepositoryFactory.php
@@ -6,6 +6,7 @@ use Interop\Container\ContainerInterface;
 
 use Detail\Persistence\Repository\DocumentRepositoryInterface;
 use Detail\Persistence\Exception;
+use Doctrine\ODM\MongoDB\DocumentManager;
 
 abstract class DocumentRepositoryFactory extends BaseRepositoryFactory
 {
@@ -24,7 +25,7 @@ abstract class DocumentRepositoryFactory extends BaseRepositoryFactory
             );
         }
 
-        /** @var \Doctrine\ODM\MongoDB\DocumentManager $documentManager */
+        /** @var DocumentManager $documentManager */
         $documentManager = $container->get('doctrine.documentmanager.odm_default');
 
         /** @var DocumentRepositoryInterface $repository */

--- a/src/Factory/Doctrine/EntityRepositoryFactory.php
+++ b/src/Factory/Doctrine/EntityRepositoryFactory.php
@@ -6,6 +6,8 @@ use Interop\Container\ContainerInterface;
 
 use Detail\Persistence\Repository\EntityRepositoryInterface;
 use Detail\Persistence\Exception;
+use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\Mapping\ClassMetadata;
 
 abstract class EntityRepositoryFactory extends BaseRepositoryFactory
 {
@@ -24,11 +26,11 @@ abstract class EntityRepositoryFactory extends BaseRepositoryFactory
             );
         }
 
-        /** @var \Doctrine\ORM\EntityManager $entityManager */
+        /** @var EntityManager $entityManager */
         $entityManager = $container->get('Doctrine\ORM\EntityManager');
         $entityRepository = $entityManager->getRepository($entityName);
 
-        /** @var \Doctrine\ORM\Mapping\ClassMetadata $metadata */
+        /** @var ClassMetadata $metadata */
         $entityMetadata = $entityManager->getClassMetadata($entityName); /** @todo Investigate if produces performance problems */
 
         /** @var EntityRepositoryInterface $repository */

--- a/src/Module.php
+++ b/src/Module.php
@@ -2,6 +2,8 @@
 
 namespace Detail\Persistence;
 
+use Traversable;
+
 use Doctrine\DBAL\Types as DoctrineOrmTypes;
 use Doctrine\ODM\MongoDB\Types as DoctrineOdmTypes;
 
@@ -28,7 +30,7 @@ class Module implements
     }
 
     /**
-     * @return array|\Traversable
+     * @return array|Traversable
      */
     public function getConfig()
     {


### PR DESCRIPTION
Candidate version 2.0 

Note: this still not fixes all problems, should require  
`"doctrine/doctrine-module": "^2" `
too, and many other "breaking"-change doctrine libraries too 

